### PR TITLE
Feature rectangular

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -363,7 +363,7 @@ function (*)(A::TriangularToeplitz, B::TriangularToeplitz)
     return full(A) * full(B)
 end
 
-# Apply a triangular Toeplitz matrix to a general column vector
+# Apply the conjugate transpose of a triangular Toeplitz matrix to a general column vector
 Ac_mul_B(A::TriangularToeplitz, b::AbstractVector) =
     TriangularToeplitz(A.ve, A.uplo == 'U' ? :L : :U, k) * b
 

--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -474,38 +474,40 @@ StatsBase.levinson(A::AbstractToeplitz, B::StridedVecOrMat) =
 #     return BlockTriangularToeplitz(Mc, string(uplo)[1], Mc_dft, tmp, dft, idft)
 # end
 
-## Hankel
-#  A hankel matrix has the form
-#
-#   [a_0 a_1 a_2;
-#    a_1 a_2 a_3;
-#    a_2 a_3 a_4]
-#
-#  This is precisely a Toeplitz matrix with the columns changed:
-#
-#   [a_2 a_1 a_0;
-#    a_3 a_2 a_1;
-#    a_4 a_3 a_2] * [0 0 1; 0 1 0; 1 0 0]
-#
-#  We represent the Hankel matrix by wrapping the corresponding Toeplitz matrix
-#
+#= Hankel Matrix
+ A Hankel matrix is a matrix that is constant across the anti-diagonals:
 
+  [a_0 a_1 a_2 a_3 a_4
+   a_1 a_2 a_3 a_4 a_5
+   a_2 a_3 a_4 a_5 a_6]
+
+ This is precisely a Toeplitz matrix with the columns reversed:
+                             [0 0 0 0 1
+  [a_4 a_3 a_2 a_1 a_0        0 0 0 1 0
+   a_5 a_4 a_3 a_2 a_1   *    0 0 1 0 0
+   a_6 a_5 a_4 a_3 a_2]       0 1 0 0 0
+                              1 0 0 0 0]
+ We represent the Hankel matrix by wrapping the corresponding Toeplitz matrix.=#
+
+# Hankel Matrix
 type Hankel{T<:Number} <: AbstractMatrix{T}
     T::Toeplitz{T}
 end
 
-
+# Ctor: vc is the leftmost column and vr is the bottom row.
 function Hankel(vc,vr)
     if vc[end] != vr[1]
-        error("First element of rows must equal first element of columns")
+        error("First element of rows must equal last element of columns")
     end
-    Hankel(Toeplitz(vr,reverse(vc)))
+    n = length(vr)
+    p = [vc; vr[2:end]]
+    Hankel(Toeplitz(p[n:end],p[n:-1:1]))
 end
 
+# Size
 size(H::Hankel,k...) = size(H.T,k...)
 
-getindex(H::Hankel, i::Integer) = H[mod(i, size(H,1)), div(i, size(H,1)) + 1]
-
+# Full version of a Hankel matrix
 function full{T}(A::Hankel{T})
     m, n = size(A)
     Af = Array(T, m, n)
@@ -517,15 +519,16 @@ function full{T}(A::Hankel{T})
     return Af
 end
 
+# Retrieve an entry by two indices
 getindex(A::Hankel, i::Integer, j::Integer) = A.T[i,end-j+1]
 
+# Retrieve an entry by one index
+getindex(H::Hankel, i::Integer) = H[mod(i, size(H,1)), div(i, size(H,1)) + 1]
+
+# Fast application of a general Hankel matrix to a general vector
 *(A::Hankel,b::AbstractVector) = A.T*reverse(b)
 
-
-
-
-## BigFloat support
-
+# BigFloat support
 (*){T<:BigFloat}(A::Toeplitz{T}, b::Vector) = irfft(
     rfft([
         A.vc;
@@ -537,4 +540,5 @@ getindex(A::Hankel, i::Integer, j::Integer) = A.T[i,end-j+1]
     2 * length(b) - 1
 )[1:length(b)]
 
-end #module
+end
+#module

--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -1,7 +1,5 @@
 module ToeplitzMatrices
 
-using Debug
-
 import StatsBase
 include("iterativeLinearSolvers.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,30 @@
 using Base.Test
 using ToeplitzMatrices
 
-ns = 10
+ns = 101
 nl = 2000
 
 xs = randn(ns, 5)
 xl = randn(nl, 5)
 
 @printf("General Toeplitz: ")
+# Square
 As = Toeplitz(0.9.^(0:ns-1), 0.4.^(0:ns-1))
 Al = Toeplitz(0.9.^(0:nl-1), 0.4.^(0:nl-1))
 @test_approx_eq As * xs full(As) * xs
 @test_approx_eq Al * xl full(Al) * xl
 @test_approx_eq A_ldiv_B!(As, copy(xs)) full(As) \ xs
 @test_approx_eq A_ldiv_B!(Al, copy(xl)) full(Al) \ xl
+
+# Rectangular
+Ar1 = Toeplitz(0.9.^(0:nl-1), 0.4.^(0:ns-1))
+Ar2 = Toeplitz(0.9.^(0:ns-1), 0.4.^(0:nl-1))
+@test_approx_eq Ar1 * xs full(Ar1) * xs
+@test_approx_eq Ar2 * xl full(Ar2) * xl
 @printf("OK!\n")
 
 @printf("Symmetric Toeplitz: ")
+# Square
 As = SymmetricToeplitz(0.9.^(0:ns-1))
 Ab = SymmetricToeplitz(abs(randn(ns)))
 Al = SymmetricToeplitz(0.9.^(0:nl-1))
@@ -29,6 +37,12 @@ Al = SymmetricToeplitz(0.9.^(0:nl-1))
 @test_approx_eq StatsBase.levinson(As, xs) full(As) \ xs
 @test_approx_eq StatsBase.levinson(Ab, xs) full(Ab) \ xs
 @test_approx_eq StatsBase.levinson(Al, xl) full(Al) \ xl
+
+# Rectangular
+Ar1 = SymmetricToeplitz(0.9.^(0:nl-1), 'c', ns)
+Ar2 = SymmetricToeplitz(0.9.^(0:nl-1), 'r', ns)
+@test_approx_eq Ar1 * xs full(Ar1) * xs
+@test_approx_eq Ar2 * xl full(Ar2) * xl
 @printf("OK!\n")
 
 @printf("Circulant: ")
@@ -41,30 +55,52 @@ Al = Circulant(0.9.^(0:nl-1))
 @printf("OK!\n")
 
 @printf("Upper triangular Toeplitz: ")
+# Square
 As = TriangularToeplitz(0.9.^(0:ns - 1), :U)
 Al = TriangularToeplitz(0.9.^(0:nl - 1), :U)
 @test_approx_eq As * xs full(As) * xs
 @test_approx_eq Al * xl full(Al) * xl
 @test_approx_eq A_ldiv_B!(As, copy(xs)) full(As) \ xs
 @test_approx_eq A_ldiv_B!(Al, copy(xl)) full(Al) \ xl
+
+# Rectangular
+Ar1 = TriangularToeplitz(0.9.^(0:ns - 1), :U, nl)
+Ar2 = TriangularToeplitz(0.9.^(0:nl - 1), :U, ns)
+@test_approx_eq Ar1 * xs full(Ar1) * xs
+@test_approx_eq Ar2 * xl full(Ar2) * xl
 @printf("OK!\n")
 
 @printf("Lower triangular Toeplitz: ")
+# Square
 As = TriangularToeplitz(0.9.^(0:ns - 1), :L)
 Al = TriangularToeplitz(0.9.^(0:nl - 1), :L)
 @test_approx_eq As * xs full(As) * xs
 @test_approx_eq Al * xl full(Al) * xl
 @test_approx_eq A_ldiv_B!(As, copy(xs)) full(As) \ xs
 @test_approx_eq A_ldiv_B!(Al, copy(xl)) full(Al) \ xl
-@printf("OK!\n")
 
+# Rectangular
+Ar1 = TriangularToeplitz(0.9.^(0:ns - 1), :L, nl)
+Ar2 = TriangularToeplitz(0.9.^(0:nl - 1), :L, ns)
+@test_approx_eq Ar1 * xl full(Ar1) * xl
+@test_approx_eq Ar2 * xs full(Ar2) * xs
+@printf("OK!\n")
 
 @printf("Hankel: ")
-H=Hankel([1.0,2,3,4,5],[5.0,6,7,8,0])
-x=ones(5)
-@test_approx_eq full(H)*x H*x
-@printf("OK!\n")
+# Square
+Hs = Hankel(0.9.^(ns-1:-1:0), 0.4.^(0:ns-1))
+Hl = Hankel(0.9.^(nl-1:-1:0), 0.4.^(0:nl-1))
+@test_approx_eq Hs * xs[:,1] full(Hs) * xs[:,1]
+@test_approx_eq Hs * xs full(Hs) * xs
+@test_approx_eq Hl * xl full(Hl) * xl
 
+# Rectangular
+Hs = Hankel(0.9.^(ns-1:-1:0), 0.4.^(0:nl-1))
+Hl = Hankel(0.9.^(nl-1:-1:0), 0.4.^(0:ns-1))
+@test_approx_eq Hs * xl[:,1] full(Hs) * xl[:,1]
+@test_approx_eq Hs * xl full(Hs) * xl
+@test_approx_eq Hl * xs full(Hl) * xs
+@printf("OK!\n")
 
 if isdir(Pkg.dir("FastTransforms"))
     @printf("BigFloat: ")
@@ -92,6 +128,5 @@ if isdir(Pkg.dir("FastTransforms"))
     r=map(BigFloat,rand(n))
     T=TriangularToeplitz(r,:U)
     @test_approx_eq T*ones(BigFloat,n) full(T)*ones(BigFloat,n)
+    @printf("OK!\n")
 end
-@printf("OK!\n")
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,12 +46,19 @@ Ar2 = SymmetricToeplitz(0.9.^(0:nl-1), 'r', ns)
 @printf("OK!\n")
 
 @printf("Circulant: ")
+# Square
 As = Circulant(0.9.^(0:ns-1))
 Al = Circulant(0.9.^(0:nl-1))
 @test_approx_eq As * xs full(As) * xs
 @test_approx_eq Al * xl full(Al) * xl
 @test_approx_eq A_ldiv_B!(As, copy(xs)) full(As) \ xs
 @test_approx_eq A_ldiv_B!(Al, copy(xl)) full(Al) \ xl
+
+# Rectangular
+Ar1 = Circulant(0.9.^(0:nl-1), 'c', ns)
+Ar2 = Circulant(0.9.^(0:nl-1), 'r', ns)
+@test_approx_eq Ar1 * xs full(Ar1) * xs
+@test_approx_eq Ar2 * xl full(Ar2) * xl
 @printf("OK!\n")
 
 @printf("Upper triangular Toeplitz: ")


### PR DESCRIPTION
Hi All,

I have added the support for rectangular Toeplitz/Hankel along with more tests. Here are a few notes:

1. The rectangular support doesn't cover left division, inverse, and multiplication of two circulant matrices. Left division for rectangular case can be introduced later in the sense of least squares. Inverse can be covered by pseudoinverse. 

2. All tests (square cases + rectangular cases) passed on my machine, except the tests for BigFloat. Here is the error message:

```
ERROR: LoadError: StackOverflowError:
 in * at /home/kuan/.julia/v0.4/FastTransforms/src/fftBigFloat.jl:133 (repeats 342 times)
while loading /home/kuan/Documents/git/ToeplitzMatrices.jl/test/runtests.jl, in expression starting on line 72
```

It has nothing to do with my commits, I think. There might be a bug in `FastTransform`. @dlfivefifty Can you take a look?

3.I have added some minimal comments for functions.

Also I have a couple of questions:

1. What is the use of function `Ac_mul_B(A::Circulant,B::Circulant)`? Conjugate of A times B? Since this function is not tested and I don't fully understand it, I didn't push a commit for its rectangular version.

2. Shall we defer the computation of the fields `vc_dft` (I have renamed it as `vcvr_dft`) and `dft` only when we really need, i.e. when a Toeplitz matrix is applied to a vector or a matrix? Currently, `vcvr_dft`and `dft` are evaluated eagerly. Since the current threshold for using the FFT algorithms is 512 (isn't this number too big?), we may compute the FFT of a vector whose length can be of 500+ but without finally using it at all. It could be a waste, depending on context. 