### PR TITLE
Support Toeplitz(A::AbstractMatrix), SymmetricToepliz(A::AbstractMatr…

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -237,13 +237,14 @@ mutable struct SymmetricToeplitz{T<:BlasReal} <: AbstractToeplitz{T}
     vcvr_dft::Vector{Complex{T}}
     tmp::Vector{Complex{T}}
     dft::Plan
-
-    function SymmetricToeplitz{T}(vc::Vector{T}) where T<:BlasReal
-        tmp = convert(Array{Complex{T}}, [vc; zero(T); reverse(vc[2:end])])
-        dft = plan_fft!(tmp)
-        return new(vc, dft*tmp, similar(tmp), dft)
-    end
 end
+
+function SymmetricToeplitz{T}(vc::Vector{T}) where T<:BlasReal
+	tmp = convert(Array{Complex{T}}, [vc; zero(T); reverse(vc[2:end])])
+	dft = plan_fft!(tmp)
+	return SymmetricToeplitz{T}(vc, dft*tmp, similar(tmp), dft)
+end
+
 
 SymmetricToeplitz{T}(vc::AbstractVector) where T<:BlasReal = SymmetricToeplitz{T}(convert(Vector{T}, vc))
 SymmetricToeplitz{T}(vc::AbstractVector{T}) where T = SymmetricToeplitz{promote_type(Float32, T)}(vc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,36 +8,37 @@ xs = randn(ns, 5)
 xl = randn(nl, 5)
 
 @testset("Toeplitz: $st",
-for (As, Al, st) in ((Toeplitz(0.9.^(0:ns-1), 0.4.^(0:ns-1)),
-                        Toeplitz(0.9.^(0:nl-1), 0.4.^(0:nl-1)),
-                            "Real general square"),
-                     (Toeplitz(complex(0.9.^(0:ns-1)), complex(0.4.^(0:ns-1))),
-                        Toeplitz(complex(0.9.^(0:nl-1)), complex(0.4.^(0:nl-1))),
-                            "Complex general square"),
-                     (Circulant(0.9.^(0:ns - 1)),
-                        Circulant(0.9.^(0:nl - 1)),
-                            "Real circulant"),
-                     (Circulant(complex(0.9.^(0:ns - 1))),
-                        Circulant(complex(0.9.^(0:nl - 1))),
-                            "Complex circulant"),
-                     (TriangularToeplitz(0.9.^(0:ns - 1), :U),
-                        TriangularToeplitz(0.9.^(0:nl - 1), :U),
-                            "Real upper triangular"),
-                     (TriangularToeplitz(complex(0.9.^(0:ns - 1)), :U),
-                        TriangularToeplitz(complex(0.9.^(0:nl - 1)), :U),
-                            "Complex upper triangular"),
-                     (TriangularToeplitz(0.9.^(0:ns - 1), :L),
-                        TriangularToeplitz(0.9.^(0:nl - 1), :L),
-                            "Real lower triangular"),
-                     (TriangularToeplitz(complex(0.9.^(0:ns - 1)), :L),
-                        TriangularToeplitz(complex(0.9.^(0:nl - 1)), :L),
-                            "Complex lower triangular"))
+    for (As, Al, st) in ((Toeplitz(0.9.^(0:ns-1), 0.4.^(0:ns-1)),
+                            Toeplitz(0.9.^(0:nl-1), 0.4.^(0:nl-1)),
+                                "Real general square"),
+                         (Toeplitz(complex(0.9.^(0:ns-1)), complex(0.4.^(0:ns-1))),
+                            Toeplitz(complex(0.9.^(0:nl-1)), complex(0.4.^(0:nl-1))),
+                                "Complex general square"),
+                         (Circulant(0.9.^(0:ns - 1)),
+                            Circulant(0.9.^(0:nl - 1)),
+                                "Real circulant"),
+                         (Circulant(complex(0.9.^(0:ns - 1))),
+                            Circulant(complex(0.9.^(0:nl - 1))),
+                                "Complex circulant"),
+                         (TriangularToeplitz(0.9.^(0:ns - 1), :U),
+                            TriangularToeplitz(0.9.^(0:nl - 1), :U),
+                                "Real upper triangular"),
+                         (TriangularToeplitz(complex(0.9.^(0:ns - 1)), :U),
+                            TriangularToeplitz(complex(0.9.^(0:nl - 1)), :U),
+                                "Complex upper triangular"),
+                         (TriangularToeplitz(0.9.^(0:ns - 1), :L),
+                            TriangularToeplitz(0.9.^(0:nl - 1), :L),
+                                "Real lower triangular"),
+                         (TriangularToeplitz(complex(0.9.^(0:ns - 1)), :L),
+                            TriangularToeplitz(complex(0.9.^(0:nl - 1)), :L),
+                                "Complex lower triangular"))
 
-    @test As * xs ≈ full(As) * xs
-    @test Al * xl ≈ full(Al) * xl
-    @test A_ldiv_B!(As, LinAlg.copy_oftype(xs, eltype(As))) ≈ full(As) \ xs
-    @test A_ldiv_B!(Al, LinAlg.copy_oftype(xl, eltype(Al))) ≈ full(Al) \ xl
-end)
+        @test As * xs ≈ full(As) * xs
+        @test Al * xl ≈ full(Al) * xl
+        @test A_ldiv_B!(As, LinAlg.copy_oftype(xs, eltype(As))) ≈ full(As) \ xs
+        @test A_ldiv_B!(Al, LinAlg.copy_oftype(xl, eltype(Al))) ≈ full(Al) \ xl
+    end
+)
 
 @testset "Real general rectangular" begin
     Ar1 = Toeplitz(0.9.^(0:nl-1), 0.4.^(0:ns-1))
@@ -184,4 +185,38 @@ end
     @test isa(convert(AbstractMatrix{Complex128},T),Hankel{Complex128})
     @test isa(convert(AbstractArray{Complex128},T),Hankel{Complex128})
     @test isa(convert(ToeplitzMatrices.Hankel{Complex128},T),Hankel{Complex128})
+
+
+    @test Circulant(1:5) == Circulant(Vector(1.0:5))
+
 end
+
+
+A = ones(10, 10)
+@test full(Toeplitz(A)) == full(Toeplitz{Float64}(A)) == A
+@test full(SymmetricToeplitz(A)) == full(SymmetricToeplitz{Float64}(A)) == A
+@test full(Circulant(A)) == full(Circulant{Float64}(A)) == A
+@test full(Hankel(A)) == full(Hankel{Float64}(A)) == A
+
+
+A = [1.0 2.0;
+     3.0 4.0]
+
+@test Toeplitz(A) == Toeplitz([1.,3.], [1.,2.])
+@test Toeplitz{Float64}(A) == Toeplitz([1.,3.], [1.,2.])
+@test full(SymmetricToeplitz(A)) == full(SymmetricToeplitz{Float64}(A)) ==
+            full(Toeplitz(Symmetric(A))) == full(Symmetric(Toeplitz(A))) == [1. 2.; 2. 1.]
+@test full(Circulant(A)) == [1 3; 3 1]
+
+@test TriangularToeplitz(A, :U) == TriangularToeplitz{Float64}(A, :U) == Toeplitz(UpperTriangular(A)) == UpperTriangular(Toeplitz(A))
+@test TriangularToeplitz(A, :L) == TriangularToeplitz{Float64}(A, :L) == Toeplitz(LowerTriangular(A)) == LowerTriangular(Toeplitz(A))
+
+@test full(Hankel(A)) == full(Hankel{Float64}(A)) == [1.0 3; 3 4]
+
+# Constructors should be projections
+@test Toeplitz(Toeplitz(A)) == Toeplitz(A)
+@test SymmetricToeplitz(SymmetricToeplitz(A)) == SymmetricToeplitz(A)
+@test Circulant(Circulant(A)) == Circulant(A)
+@test TriangularToeplitz(TriangularToeplitz(A, :U), :U) == TriangularToeplitz(A, :U)
+@test TriangularToeplitz(TriangularToeplitz(A, :L), :L) == TriangularToeplitz(A, :L)
+@test Hankel(Hankel(A)) == Hankel(A)


### PR DESCRIPTION
…ix), etc.. for projecting on to Toeplitz matrices.

This follows discussion in https://github.com/JuliaLang/julia/issues/24595#issuecomment-347281822

It also supports creating zero/ones/identity matrices via FillArrays.jl (without making it a dependancy):
```julia
julia> using ToeplitzMatrices, FillArrays

julia> Toeplitz(Zeros(5,5))
5×5 ToeplitzMatrices.Toeplitz{Float64,Complex{Float64}}:
 0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0

julia> Toeplitz(Eye(5))
5×5 ToeplitzMatrices.Toeplitz{Float64,Complex{Float64}}:
 1.0  0.0  0.0  0.0  0.0
 0.0  1.0  0.0  0.0  0.0
 0.0  0.0  1.0  0.0  0.0
 0.0  0.0  0.0  1.0  0.0
 0.0  0.0  0.0  0.0  1.0
```