### PR TITLE
Fix indexing

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -31,7 +31,9 @@ include("iterativeLinearSolvers.jl")
 abstract type AbstractToeplitz{T<:Number} <: AbstractMatrix{T} end
 
 size(A::AbstractToeplitz) = (size(A, 1), size(A, 2))
-getindex(A::AbstractToeplitz, i::Integer) = A[mod(i, size(A,1)), div(i, size(A,1)) + 1]
+function getindex(A::AbstractToeplitz, i::Integer)
+    return A[mod(i - 1, size(A, 1)) + 1, div(i - 1, size(A, 1)) + 1]
+end
 
 convert(::Type{AbstractMatrix{T}}, S::AbstractToeplitz) where {T} = convert(AbstractToeplitz{T}, S)
 convert(::Type{AbstractArray{T}}, S::AbstractToeplitz) where {T} = convert(AbstractToeplitz{T}, S)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,9 @@ end
 ns = 101
 nl = 2000
 
+ns = 2
+nl = 3
+
 xs = randn(ns, 5)
 xl = randn(nl, 5)
 
@@ -39,6 +42,8 @@ xl = randn(nl, 5)
 
         @test As * xs ≈ Matrix(As) * xs
         @test Al * xl ≈ Matrix(Al) * xl
+        @test [As[n] for n in 1:length(As)] == vec(As)
+        @test [Al[n] for n in 1:length(Al)] == vec(Al)
         @test ldiv!(As, Compat.LinearAlgebra.copy_oftype(xs, eltype(As))) ≈ Matrix(As) \ xs
         @test ldiv!(Al, Compat.LinearAlgebra.copy_oftype(xl, eltype(Al))) ≈ Matrix(Al) \ xl
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,6 @@ end
 ns = 101
 nl = 2000
 
-ns = 2
-nl = 3
-
 xs = randn(ns, 5)
 xl = randn(nl, 5)
 


### PR DESCRIPTION
Fixes a bug in linear indexing and adds corresponding unit tests to prevent bug reappearing. Run the following on master to reproduce the bug:
```julia
using ToeplitzMatrices
x, x′ = randn(4), randn(3)
x′[1] = x[1]
T = Toeplitz(x′, x)
[T[n] for n in 1:length(T)]
```