### PR TITLE
Fix consistency of inverse of Circulant matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ToeplitzMatrices"
 uuid = "c751599d-da0a-543b-9d20-d0a503d91d24"
-version = "0.6"
+version = "0.6.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ToeplitzMatrices, StatsBase, Test, LinearAlgebra
 
 using Base: copyto!
+using FFTW: fft
 
 ns = 101
 nl = 2000
@@ -255,22 +256,28 @@ end
     C = inv(C1)
     @test C isa Circulant
     @test C ≈ inv(M1)
+    @test fft(C.vc) ≈ C.vcvr_dft
     C = inv(C3)
     @test C isa Circulant
     @test C ≈ inv(M3)
+    @test fft(C.vc) ≈ C.vcvr_dft
 
     C = pinv(C1)
     @test C isa Circulant
     @test C ≈ pinv(M1)
+    @test fft(C.vc) ≈ C.vcvr_dft
     C = pinv(C3)
     @test C isa Circulant
     @test C ≈ pinv(M3)
+    @test fft(C.vc) ≈ C.vcvr_dft
     C = pinv(C4)
     @test C isa Circulant
     @test C ≈ pinv(M4)
+    @test fft(C.vc) ≈ C.vcvr_dft
     C = pinv(C5)
     @test C isa Circulant
     @test C ≈ pinv(M5)
+    @test fft(C.vc) ≈ C.vcvr_dft
 
     C = sqrt(C1)
     @test C isa Circulant

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,6 +297,12 @@ end
     for v1i in v1
         @test minimum(abs.(v1i .- v2)) < sqrt(eps(Float64))
     end
+
+    # Test for issue #47
+    I = inv(C1)*C1
+    e = rand(5)
+    # I should be close to identity
+    @test I*e ≈ e
 end
 
 @testset "Cholesky" begin


### PR DESCRIPTION
The `inv` and `pinv` routines of a circulant matrix C use the planned transform C.dft on a vector. Since the transform is in-place, this overwrites the vector. That made the vc and vcvr_dft fields of the resulting Circulant matrix inconsistent (the latter should be the fft of the former). Fixed by copying the vector prior to the transform, rather than after the transform as it was before.
I've added tests, for which I had to add "using FFTW: fft" to the test suite.

I've also added an additional multiplication to preserve real circulant matrices after multiplication (the output was a complex circulant matrix).