### PR TITLE
adjoint of toeplitz for fast A'x

### DIFF
--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -176,8 +176,8 @@ convert(::Type{AbstractToeplitz{T}}, A::Toeplitz) where {T} = convert(Toeplitz{T
 convert(::Type{Toeplitz{T}}, A::Toeplitz) where {T} = Toeplitz(convert(Vector{T}, A.vc),
                                                                convert(Vector{T}, A.vr))
 
-adjoint(A::Toeplitz{T}) where T = Toeplitz(conj(A.vr), conj(A.vc))
-adjoint(A::Toeplitz{<:Real}) where T = transpose(A)
+adjoint(A::Toeplitz) = Toeplitz(conj(A.vr), conj(A.vc))
+adjoint(A::Toeplitz{<:Real}) = transpose(A)
 transpose(A::Toeplitz) = Toeplitz(A.vr, A.vc)
 
 # Size of a general Toeplitz matrix
@@ -267,7 +267,7 @@ SymmetricToeplitz(A::AbstractMatrix) = SymmetricToeplitz{eltype(A)}(A)
 convert(::Type{AbstractToeplitz{T}}, A::SymmetricToeplitz) where {T} = convert(SymmetricToeplitz{T},A)
 convert(::Type{SymmetricToeplitz{T}}, A::SymmetricToeplitz) where {T} = SymmetricToeplitz(convert(Vector{T},A.vc))
 
-adjoint(A::SymmetricToeplitz{T}) where T = SymmetricToeplitz(conj(A.vr), conj(A.vc))
+adjoint(A::SymmetricToeplitz) = SymmetricToeplitz(conj(A.vr), conj(A.vc))
 adjoint(A::SymmetricToeplitz{<:Real}) = A
 transpose(A::SymmetricToeplitz) = A
 

--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -2,7 +2,7 @@ module ToeplitzMatrices
 using StatsBase
 
 
-import Base: convert, *, \, getindex, print_matrix, size, Matrix, +, -, copy, similar, sqrt, copyto!
+import Base: convert, *, \, getindex, print_matrix, size, Matrix, +, -, copy, similar, sqrt, copyto!, adjoint
 import LinearAlgebra: BlasReal, Cholesky, DimensionMismatch, cholesky, cholesky!, eigvals, inv, ldiv!,
     mul!, pinv, rmul!, tril, triu
 
@@ -174,6 +174,8 @@ Toeplitz{T}(A::AbstractMatrix) where T = Toeplitz{T}(A[:,1], A[1,:])
 convert(::Type{AbstractToeplitz{T}}, A::Toeplitz) where {T} = convert(Toeplitz{T}, A)
 convert(::Type{Toeplitz{T}}, A::Toeplitz) where {T} = Toeplitz(convert(Vector{T}, A.vc),
                                                                convert(Vector{T}, A.vr))
+
+adjoint(A::Toeplitz) = Toeplitz(A.vr, A.vc)
 
 # Size of a general Toeplitz matrix
 function size(A::Toeplitz, dim::Int)

--- a/src/ToeplitzMatrices.jl
+++ b/src/ToeplitzMatrices.jl
@@ -2,7 +2,8 @@ module ToeplitzMatrices
 using StatsBase
 
 
-import Base: convert, *, \, getindex, print_matrix, size, Matrix, +, -, copy, similar, sqrt, copyto!, adjoint
+import Base: convert, *, \, getindex, print_matrix, size, Matrix, +, -, copy, similar, sqrt, copyto!,
+    adjoint, transpose
 import LinearAlgebra: BlasReal, Cholesky, DimensionMismatch, cholesky, cholesky!, eigvals, inv, ldiv!,
     mul!, pinv, rmul!, tril, triu
 
@@ -175,7 +176,9 @@ convert(::Type{AbstractToeplitz{T}}, A::Toeplitz) where {T} = convert(Toeplitz{T
 convert(::Type{Toeplitz{T}}, A::Toeplitz) where {T} = Toeplitz(convert(Vector{T}, A.vc),
                                                                convert(Vector{T}, A.vr))
 
-adjoint(A::Toeplitz) = Toeplitz(A.vr, A.vc)
+adjoint(A::Toeplitz{T}) where T = Toeplitz(conj(A.vr), conj(A.vc))
+adjoint(A::Toeplitz{<:Real}) where T = transpose(A)
+transpose(A::Toeplitz) = Toeplitz(A.vr, A.vc)
 
 # Size of a general Toeplitz matrix
 function size(A::Toeplitz, dim::Int)
@@ -263,6 +266,10 @@ SymmetricToeplitz(A::AbstractMatrix) = SymmetricToeplitz{eltype(A)}(A)
 
 convert(::Type{AbstractToeplitz{T}}, A::SymmetricToeplitz) where {T} = convert(SymmetricToeplitz{T},A)
 convert(::Type{SymmetricToeplitz{T}}, A::SymmetricToeplitz) where {T} = SymmetricToeplitz(convert(Vector{T},A.vc))
+
+adjoint(A::SymmetricToeplitz{T}) where T = SymmetricToeplitz(conj(A.vr), conj(A.vc))
+adjoint(A::SymmetricToeplitz{<:Real}) = A
+transpose(A::SymmetricToeplitz) = A
 
 function size(A::SymmetricToeplitz, dim::Int)
     if 1 <= dim <= 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,12 +35,15 @@ xl = randn(nl, 5)
                             TriangularToeplitz(complex(0.9.^(0:nl - 1)), :L),
                                 "Complex lower triangular"))
 
-        @test As * xs ≈ Matrix(As) * xs
-        @test Al * xl ≈ Matrix(Al) * xl
+        @test As * xs ≈ Matrix(As)  * xs
+        @test As'* xs ≈ Matrix(As)' * xs
+        @test Al * xl ≈ Matrix(Al)  * xl
+        @test Al'* xl ≈ Matrix(Al)' * xl
         @test [As[n] for n in 1:length(As)] == vec(As)
         @test [Al[n] for n in 1:length(Al)] == vec(Al)
         @test ldiv!(As, LinearAlgebra.copy_oftype(xs, eltype(As))) ≈ Matrix(As) \ xs
         @test ldiv!(Al, LinearAlgebra.copy_oftype(xl, eltype(Al))) ≈ Matrix(Al) \ xl
+        @test Matrix(As') == Matrix(As)'
     end
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ xl = randn(nl, 5)
         @test ldiv!(As, LinearAlgebra.copy_oftype(xs, eltype(As))) ≈ Matrix(As) \ xs
         @test ldiv!(Al, LinearAlgebra.copy_oftype(xl, eltype(Al))) ≈ Matrix(Al) \ xl
         @test Matrix(As') == Matrix(As)'
+        @test Matrix(transpose(As)) == transpose(Matrix(As))
     end
 )
 


### PR DESCRIPTION
This PR partly solves #52 by implementing `adjoint` and `transpose` for some of the types.