### PR TITLE
Update Travis link to .com in README.md and remove hardcoding of

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.5
+  - 1
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ToeplitzMatrices.jl
 ===========
 
-[![Build Status](https://travis-ci.org/JuliaMatrices/ToeplitzMatrices.jl.svg?branch=master)](https://travis-ci.org/JuliaMatrices/ToeplitzMatrices.jl)
+[![Build Status](https://travis-ci.com/JuliaMatrices/ToeplitzMatrices.jl.svg?branch=master)](https://travis-ci.com/JuliaMatrices/ToeplitzMatrices.jl)
 [![codecov](https://codecov.io/gh/JuliaMatrices/ToeplitzMatrices.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaMatrices/ToeplitzMatrices.jl)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaMatrices/ToeplitzMatrices.jl/badge.svg?branch=master&bust=1)](https://coveralls.io/github/JuliaMatrices/ToeplitzMatrices.jl?branch=master)
 


### PR DESCRIPTION
testing on Julia 1.5 in favor of testing on current release version.

Closes https://github.com/JuliaMatrices/ToeplitzMatrices.jl/issues/55