### PR TITLE
drop support for Julia <v1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1.6'
           - '1'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ToeplitzMatrices"
 uuid = "c751599d-da0a-543b-9d20-d0a503d91d24"
-version = "0.8.2"
+version = "0.9.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ToeplitzMatrices"
 uuid = "c751599d-da0a-543b-9d20-d0a503d91d24"
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -14,7 +14,7 @@ Aqua = "0.6"
 DSP = "0.7.7"
 FFTW = "1"
 StatsBase = "0.32, 0.33, 0.34"
-julia = "1.0"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
It's unlikely that users of Julia v1.0 would want the latest versions of packages, so it makes sense to restrict further development to v1.6. In any case, this is meant to be merged along with the next breaking release, so that v0.8 may still receive backported changes, if necessary.