### PR TITLE
WIP: Adds operator Base.:*(::ToeplitzFactorization, ::StridedVector)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -553,3 +553,77 @@ end
     @test cholesky(T).U ≈ cholesky(Matrix(T)).U
     @test cholesky(T).L ≈ cholesky(Matrix(T)).L
 end
+
+
+@testset "NEW TODO MODIFY" begin
+    function getdata(m=1760, n=4097)
+
+        T = Toeplitz{Float64}(
+            [1.0; rand([0.0, 1.0], m-1)],
+            [1.0; rand([0.0, 1.0], n-1)],
+        )
+
+        x = rand(Float64[0, 1], n)
+
+        return T, x
+    end
+
+    @testset "adsf" begin
+        T, x = getdata()
+
+        correct_result = T * x
+
+        Tfac = factorize(T)
+
+        result = zeros(Float64, 1760)
+        @test Tfac * x == T * x == correct_result
+        @test Tfac * x == correct_result  # can(!) reuse factorization 
+        @test Tfac * x == correct_result == mul!(result, Tfac, x, 1.0, 0.0)  # modifies Tfac.tmp
+        @test correct_result == mul!(result, Tfac, x, 1.0, 0.0)  # but we still can reuse factorization!
+
+        result = zeros(Float64, 1760)
+
+        xcopy = copy(x)
+
+        @test mul!(result, factorize(T), x, 1.0, 0.0) == correct_result
+        @test result == correct_result
+        @test x == xcopy
+
+        @test mul!(result, factorize(T), x, 1.0, 0.0) == correct_result
+        # @test mul!(result, factorize(T), x, 1.0, 1.0) == correct_result
+
+    end
+
+    @testset "threaded mul!" begin
+        
+        T, x = getdata()
+        Tfac = factorize(T)
+        result = zeros(Float64, 1760)
+
+        correct_result = T * x
+
+        valid = Bool[]
+        Base.Threads.@threads for i = 1:100
+            push!(valid, mul!(result, factorize(T), x, 1.0, 0.0) == correct_result)
+        end
+        @test all(valid)
+    end
+
+
+    @testset "threaded mul! (Broken!!!!)" begin
+        
+        T, x = getdata()
+        Tfac = factorize(T)
+        result = zeros(Float64, 1760)
+
+        correct_result = T * x
+
+        Tfac = factorize(T)
+        valid = Bool[]
+        Base.Threads.@threads for i = 1:100
+            push!(valid, mul!(result, Tfac, x, 1.0, 0.0) == correct_result)
+        end
+        @test all(valid)    broken=true
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -610,20 +610,20 @@ end
     end
 
 
-    @testset "threaded mul! (Broken!!!!)" begin
+    # @testset "threaded mul! (Broken!!!!)" begin
         
-        T, x = getdata()
-        Tfac = factorize(T)
-        result = zeros(Float64, 1760)
+    #     T, x = getdata()
+    #     Tfac = factorize(T)
+    #     result = zeros(Float64, 1760)
 
-        correct_result = T * x
+    #     correct_result = T * x
 
-        Tfac = factorize(T)
-        valid = Bool[]
-        Base.Threads.@threads for i = 1:100
-            push!(valid, mul!(result, Tfac, x, 1.0, 0.0) == correct_result)
-        end
-        @test all(valid)    broken=true
-    end
+    #     Tfac = factorize(T)
+    #     valid = Bool[]
+    #     Base.Threads.@threads for i = 1:100
+    #         push!(valid, mul!(result, Tfac, x, 1.0, 0.0) == correct_result)
+    #     end
+    #     @test all(valid)    broken=true
+    # end
 
 end


### PR DESCRIPTION
For performing many Toeplitz-vector  products using the same matrix, it is efficient to reuse the factorization of the Toeplitz matrix. The README suggests that this is intended, however it's not documented how to do it. I found out ([1](
https://github.com/JuliaLinearAlgebra/ToeplitzMatrices.jl/issues), [2](https://discourse.julialang.org/t/reusing-fftw-plan-inside-factorization-across-multiple-threads/100068/2)) that this works:
```julia
using ToeplitzMatrices, LinearAlgebra, Test
T = Toeplitz([0.;randn(499)], [0.;randn(999)])
x = randn(1000)
Tfac = factorize(T)
result = zeros(Float64, 500); @test mul!(result, Tfac, x, 1., 0.) == T*x
```
The method facilitating this is 
```julia
mul!(y::StridedVector{T} where T, A::ToeplitzMatrices.ToeplitzFactorization, x::StridedVector{T} where T, α::Number, β::Number) @ ToeplitzMatrices ~/.julia/packages/ToeplitzMatrices/5gW1c/src/linearalgebra.jl:42
```
Besides being undocumented, it modifies the `temp` buffer inside the factorization `A`. This doesn't invalidate the factorization object (because the buffer is "temporary", I guess) but the method is **not thread-safe**. I think the way to make it thread-safe is to make a copy of the `tmp` buffer and thus not changing it. However, this obviously has an unwanted performance overhead and I don't know if thread-safety of the method (is it internal? is exporting it intented) is desired. I also didn't look at other similar methods.

I suggest possible measures including
1.  Make this `mul!` method thread safe, perhaps  controlled by a parameter making it thread-safe by default but avoiding the copy when the factorization is not being reused
2. Add an operator `Base.:*(::ToeplitzFactorization, ::StridedVector)` that is thread-safe.
 
I implemented a suggestion for measure 2. I added comments indicating how one may approach measure 1. What do you think?

The code is not ready to merge, it has a lot of comments that should be removed and additional unit tests that illustrate my points, rather than properly testing functionality.